### PR TITLE
better styles on Account.ejs

### DIFF
--- a/views/web/account.ejs
+++ b/views/web/account.ejs
@@ -271,7 +271,11 @@
 
             <div>
               <div class="flex items-center justify-between mb-4">
-                <h3 class="text-lg font-medium">2FA (In devloppement)</h3>
+                <h3 class="text-lg font-medium">2FA</h3>
+                <span
+                  class="inline-flex items-center justify-center px-4 text-sm font-medium text-blue-800 bg-blue-100 rounded-full dark:bg-blue-900 dark:text-blue-300"
+                  >Under development</span
+                >
                 <label class="relative inline-flex items-center cursor-pointer">
                   <input type="checkbox" class="sr-only peer" disabled />
                   <div
@@ -356,10 +360,13 @@
           </div>
 
           <div class="settings-card rounded-xl p-6">
-            <h2 class="text-xl font-semibold mb-6">
-              Change language (In developpement)
-            </h2>
+            <h2 class="text-xl font-semibold mb-6">Change language</h2>
             <div class="space-y-4">
+              <span
+                class="inline-flex items-center justify-center px-4 text-sm font-medium text-blue-800 bg-blue-100 rounded-full dark:bg-blue-900 dark:text-blue-300"
+                >Under development</span
+              >
+
               <div
                 class="flex items-center justify-between p-4 bg-gray-800/30 rounded-lg hover:bg-gray-700/40 transition cursor-pointer"
               >
@@ -396,10 +403,13 @@
           </div>
 
           <div class="glass-card rounded-xl p-6">
-            <h2 class="text-xl font-semibold mb-6">
-              Recent logins (In developpement)
-            </h2>
+            <h2 class="text-xl font-semibold mb-6">Recent logins</h2>
             <div class="space-y-4">
+              <span
+                class="inline-flex items-center justify-center px-4 text-sm font-medium text-blue-800 bg-blue-100 rounded-full dark:bg-blue-900 dark:text-blue-300"
+                >Under development</span
+              >
+
               <div
                 class="flex items-center justify-between p-4 bg-gray-800/30 rounded-lg"
               >


### PR DESCRIPTION
Hello, I'm Vapiro.

In this pull request, I'm making the following changes to the account.ejs view:

The text “In development” (formerly displayed as brackets) has been replaced by “Under Development” for the sections :

2FA

Language Change

Login History

The style of the “Under Maintenance” section has been improved for a more aesthetic and consistent look.

These changes aim to improve the readability and uniformity of the user interface, as well as providing a better indication of the state of development of features.

Here's a before and after:

Before:
![image](https://github.com/user-attachments/assets/aaef4e60-ab0c-4481-ad10-faadd8344de5)
![image](https://github.com/user-attachments/assets/587921e2-08a9-435b-92d0-f25010fc0802)


After:
![image](https://github.com/user-attachments/assets/c3502841-85b4-4042-8727-f8f7c71c1c38)
![image](https://github.com/user-attachments/assets/d979ffa3-8470-4794-a893-b933bb992f3c)
