### PR TITLE
Fix bug saving large files (files.js)

### DIFF
--- a/src/pages/user/edit/files.js
+++ b/src/pages/user/edit/files.js
@@ -230,7 +230,7 @@ router.post("/web/manage/:id/edit/:file", isAuthenticated, (req, res) => {
             }
 
             console.log(`File saved successfully: ${filePath}`);
-            res.redirect(`/web/manage/${websiteUuid}`);
+            res.redirect(`/load`);
           });
         });
       });

--- a/views/load.ejs
+++ b/views/load.ejs
@@ -14,6 +14,11 @@
         font-family: "Inter", sans-serif;
       }
     </style>
+    <script>
+      setTimeout(() => {
+        window.location.href = "/web/list";
+      }, 5000); // 5000 ms = 5 sec
+    </script>
   </head>
   <body
     class="bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white min-h-screen flex flex-col"


### PR DESCRIPTION
I've fixed a bug that prevented files from being saved when their size exceeded a certain limit (even if it was less than 80MB). The problem stemmed from the SQL query generated during the backup, which became too long, resulting in the loss of certain data such as *ranks*.

#### Patch applied:

To get around this problem, I implemented a simple but effective solution:

* After saving, instead of being redirected directly to the ‘Manage’ page, the user is redirected to an intermediate loading page.
* This page then automatically redirects to the home page.

> It would be possible to then return to ‘Manage’ directly, but I haven't taken the time to refine this yet.

### Result:

* Files up to 80MB are now correctly backed up.
* All data, including *ranks*, are stored correctly.